### PR TITLE
SourceClear: fixes for vulnerable libraries

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "An example PHP project using Composer to demonstrate SourceClear scans.",
     "type": "project",
     "require": {
-      "moodle/moodle": "2.6.2",
-      "appserver-io/http": "1.1.6"
+      "moodle/moodle": "v3.9.3",
+      "appserver-io/http": "1.1.7"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -1,10 +1,10 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "cb693fc7725f817ca207af940a2bb817",
+    "content-hash": "57073d0a456b3a359b4dfb373b23f917",
     "packages": [
         {
             "name": "appserver-io-psr/http-message",
@@ -69,16 +69,16 @@
         },
         {
             "name": "appserver-io/http",
-            "version": "1.1.6",
+            "version": "1.1.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/appserver-io/http.git",
-                "reference": "07cecee646cc2200eb49509106a02413c45188b5"
+                "reference": "e9c716dbf71a81ea592a3475db0ccdef28c5ad4f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/appserver-io/http/zipball/07cecee646cc2200eb49509106a02413c45188b5",
-                "reference": "07cecee646cc2200eb49509106a02413c45188b5",
+                "url": "https://api.github.com/repos/appserver-io/http/zipball/e9c716dbf71a81ea592a3475db0ccdef28c5ad4f",
+                "reference": "e9c716dbf71a81ea592a3475db0ccdef28c5ad4f",
                 "shasum": ""
             },
             "require": {
@@ -136,7 +136,7 @@
                 "protocol",
                 "server"
             ],
-            "time": "2015-10-19T15:57:43+00:00"
+            "time": "2015-11-13T11:27:30+00:00"
         },
         {
             "name": "ircmaxell/password-compat",
@@ -182,26 +182,33 @@
         },
         {
             "name": "moodle/moodle",
-            "version": "v2.6.2",
+            "version": "v3.9.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/moodle/moodle.git",
-                "reference": "ef0ee34df09859681f91d5544437faa3551ae213"
+                "reference": "a8e089a8c86fa2a7a04a2f4adf39de4bbd188975"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/moodle/moodle/zipball/ef0ee34df09859681f91d5544437faa3551ae213",
-                "reference": "ef0ee34df09859681f91d5544437faa3551ae213",
+                "url": "https://api.github.com/repos/moodle/moodle/zipball/a8e089a8c86fa2a7a04a2f4adf39de4bbd188975",
+                "reference": "a8e089a8c86fa2a7a04a2f4adf39de4bbd188975",
                 "shasum": ""
             },
             "require-dev": {
-                "moodlehq/behat-extension": "1.26.7",
-                "phpunit/dbunit": "1.2.*",
-                "phpunit/phpunit": "3.7.*"
+                "instaclick/php-webdriver": "dev-local as 1.x-dev",
+                "mikey179/vfsstream": "^1.6",
+                "moodlehq/behat-extension": "3.39.3",
+                "phpunit/dbunit": "4.0.*",
+                "phpunit/phpunit": "7.5.*"
             },
-            "type": "library",
+            "type": "project",
             "notification-url": "https://packagist.org/downloads/",
-            "time": "2014-03-07T17:51:51+00:00"
+            "license": [
+                "GPL-3.0-or-later"
+            ],
+            "description": "Moodle - the world's open source learning platform",
+            "homepage": "https://moodle.org",
+            "time": "2020-11-07T15:48:07+00:00"
         }
     ],
     "packages-dev": [],


### PR DESCRIPTION
This pull request was generated by SourceClear to upgrade the following vulnerable libraries:

| Type | Library | From | To |
| --- | --- | --- | --- |
| COMPOSER | `moodle/moodle` | v2.6.2 | v3.9.3 |
| COMPOSER | `appserver-io/http` | 1.1.6 | 1.1.7 |

Note that we only upgrade libraries which have versions without any known vulnerabilities. For more information, please see the corresponding [SourceClear report](https://sca.analysiscenter.veracode.com/teams/X33hRz3/scans/25697676).

Please verify that the changes here won't cause issues with your project before merging.

To learn more about this feature, please visit our [Help Center](https://help.veracode.com/reader/hHHR3gv0wYc2WbCclECf_A/root) for documentation.

Note: this pull request was generated because you or someone else with access to this repository granted SourceClear access to submit pull requests.
<!-- srcclr-pr-id-d15157e9613a1f333bf660e816736798440abe2ec26629c8dfa73e77d208c8d2 -->
