### PR TITLE
Veracode SCA: fixes for vulnerable libraries

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "An example PHP project using Composer to demonstrate SourceClear scans.",
     "type": "project",
     "require": {
-      "moodle/moodle": "2.6.2",
-      "appserver-io/http": "1.1.6"
+      "moodle/moodle": "v3.10.4",
+      "appserver-io/http": "1.1.7"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -1,10 +1,10 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "cb693fc7725f817ca207af940a2bb817",
+    "content-hash": "0d4a2851c928c6f7e371f13be3538e01",
     "packages": [
         {
             "name": "appserver-io-psr/http-message",
@@ -69,16 +69,16 @@
         },
         {
             "name": "appserver-io/http",
-            "version": "1.1.6",
+            "version": "1.1.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/appserver-io/http.git",
-                "reference": "07cecee646cc2200eb49509106a02413c45188b5"
+                "reference": "e9c716dbf71a81ea592a3475db0ccdef28c5ad4f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/appserver-io/http/zipball/07cecee646cc2200eb49509106a02413c45188b5",
-                "reference": "07cecee646cc2200eb49509106a02413c45188b5",
+                "url": "https://api.github.com/repos/appserver-io/http/zipball/e9c716dbf71a81ea592a3475db0ccdef28c5ad4f",
+                "reference": "e9c716dbf71a81ea592a3475db0ccdef28c5ad4f",
                 "shasum": ""
             },
             "require": {
@@ -136,7 +136,7 @@
                 "protocol",
                 "server"
             ],
-            "time": "2015-10-19T15:57:43+00:00"
+            "time": "2015-11-13T11:27:30+00:00"
         },
         {
             "name": "ircmaxell/password-compat",
@@ -182,26 +182,31 @@
         },
         {
             "name": "moodle/moodle",
-            "version": "v2.6.2",
+            "version": "v3.10.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/moodle/moodle.git",
-                "reference": "ef0ee34df09859681f91d5544437faa3551ae213"
+                "reference": "237f4ccada7c8ba85ac9391193293491d8953018"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/moodle/moodle/zipball/ef0ee34df09859681f91d5544437faa3551ae213",
-                "reference": "ef0ee34df09859681f91d5544437faa3551ae213",
+                "url": "https://api.github.com/repos/moodle/moodle/zipball/237f4ccada7c8ba85ac9391193293491d8953018",
+                "reference": "237f4ccada7c8ba85ac9391193293491d8953018",
                 "shasum": ""
             },
             "require-dev": {
-                "moodlehq/behat-extension": "1.26.7",
-                "phpunit/dbunit": "1.2.*",
-                "phpunit/phpunit": "3.7.*"
+                "mikey179/vfsstream": "^1.6",
+                "moodlehq/behat-extension": "3.310.3",
+                "phpunit/phpunit": "8.5.*"
             },
-            "type": "library",
+            "type": "project",
             "notification-url": "https://packagist.org/downloads/",
-            "time": "2014-03-07T17:51:51+00:00"
+            "license": [
+                "GPL-3.0-or-later"
+            ],
+            "description": "Moodle - the world's open source learning platform",
+            "homepage": "https://moodle.org",
+            "time": "2021-05-08T14:40:42+00:00"
         }
     ],
     "packages-dev": [],


### PR DESCRIPTION
This pull request was generated by Veracode SCA to upgrade the following vulnerable libraries:

| Type | Library | From | To |
| --- | --- | --- | --- |
| COMPOSER | `moodle/moodle` | v2.6.2 | v3.10.4 |
| COMPOSER | `appserver-io/http` | 1.1.6 | 1.1.7 |

Note that we only upgrade libraries which have versions without any known vulnerabilities. For more information, please see the corresponding [Veracode SCA report](https://sca.analysiscenter.veracode.com/teams/X33hRz3/scans/27289511).

Please verify that the changes here won't cause issues with your project before merging.

To learn more about this feature, please visit our [Help Center](https://help.veracode.com/r/About_Automatic_Pull_Requests) for documentation.

Note: this pull request was generated because you or someone else with access to this repository granted Veracode SCA access to submit pull requests.
<!-- srcclr-pr-id-187107859f849ed303553de8c7a7a9ff4e8a90cf6f9deb89c18a930009f7471a -->
